### PR TITLE
fix: ConditioningMultiplier_PoP's Invalid input types

### DIFF
--- a/Conditioning_PoP.py
+++ b/Conditioning_PoP.py
@@ -9,7 +9,7 @@ class ConditioningMultiplier_PoP:
     
     def multiply_conditioning_strength(self, conditioning, multiplier):
         # Validate the input types for 'conditioning' and 'multiplier'
-        if not isinstance(conditioning, list) or not isinstance(multiplier, float):
+        if not isinstance(conditioning, list) or (not isinstance(multiplier, float) and not isinstance(multiplier, int)):
             raise ValueError("Invalid input types")
 
         #Initialize a new list to store the modified conditioning objects


### PR DESCRIPTION
fix: When the multiplier value is an integer (e.g. 1.0, 2.0, ...), 
an error occurs when the type randomly becomes an int instead of a float, and it needs to be handled.