### PR TITLE
Fix API key setup instructions

### DIFF
--- a/HOW_TO_SET_OAI_API_KEY_.txt
+++ b/HOW_TO_SET_OAI_API_KEY_.txt
@@ -22,3 +22,5 @@
 ### For Unix/Linux/Mac:
 1. Open Terminal.
 2. Add `export OPENAI_API_KEY="Your-API-Key"` to your shell profile file (like `.bashrc` or `.zshrc`).
+3. Reload your profile with `source ~/.bashrc` or `source ~/.zshrc`.
+4. Verify the variable by running `echo $OPENAI_API_KEY`.


### PR DESCRIPTION
## Summary
- complete the Unix/Linux/Mac section in HOW_TO_SET_OAI_API_KEY_.txt
- normalize line endings

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile AdaptiveCannyDetector_PoP.py AnyAspectRatio.py CNutil.py Conditioning_PoP.py EfficientAttentionNode_PoP.py openAI_PoP.py LoadImageResizer_PoP.py LoraStackLoaders_PoP.py VAEEncodeDecodeLoader_PoP.py __init__.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6841188e8418832a88ff1ef59456c3d7)